### PR TITLE
Support vehicles on loan in forms and views

### DIFF
--- a/fleet/forms.py
+++ b/fleet/forms.py
@@ -14,6 +14,7 @@ from django.contrib import admin
 import requests
 from datetime import timedelta
 from django.conf import settings
+from django.db.models import Q
 
 class TripFromTimetableForm(forms.ModelForm):
     trip_route = forms.ModelChoiceField(
@@ -47,7 +48,7 @@ class TripFromTimetableForm(forms.ModelForm):
 
         if self.operator:
             self.fields['trip_route'].queryset = route.objects.filter(route_operators=self.operator)
-            self.fields['trip_vehicle'].queryset = fleet.objects.filter(operator=self.operator)
+            self.fields['trip_vehicle'].queryset = fleet.objects.filter(Q(operator=self.operator ) | Q(loan_operator=self.operator))
             self.debug_info["init"]["route_count"] = self.fields['trip_route'].queryset.count()
             self.debug_info["init"]["vehicle_count"] = self.fields['trip_vehicle'].queryset.count()
 
@@ -192,7 +193,7 @@ class ManualTripForm(forms.ModelForm):
 
         super().__init__(*args, **kwargs)
         if self.operator:
-            self.fields['trip_vehicle'].queryset = fleet.objects.filter(operator=self.operator)
+            self.fields['trip_vehicle'].queryset = fleet.objects.filter(Q(operator=self.operator ) | Q(loan_operator=self.operator))
             self.fields['trip_route'].queryset = route.objects.filter(route_operators=self.operator)
 
         if self.vehicle:

--- a/fleet/views.py
+++ b/fleet/views.py
@@ -1004,10 +1004,17 @@ def vehicle_detail(request, operator_slug, vehicle_id):
 
     trips_json = serialize('json', trips)
 
+    bread_operator = {'name': operator.operator_name, 'url': f'/operator/{operator.operator_slug}/'}
+
+    if vehicle.loan_operator and vehicle.loan_operator != operator:
+        bread_operator = {'name': f"{vehicle.loan_operator.operator_name} (on loan from {operator.operator_name})", 'url': f'/operator/{operator.operator_slug}/'}
+
+    bread_operator_slug = vehicle.loan_operator.operator_slug if vehicle.loan_operator and vehicle.loan_operator != operator else operator.operator_slug
+
     breadcrumbs = [
         {'name': 'Home', 'url': '/'},
-        {'name': operator.operator_name, 'url': f'/operator/{operator.operator_slug}/'},
-        {'name': 'Vehicles', 'url': f'/operator/{operator.operator_slug}/vehicles#{vehicle.fleet_number}-{vehicle.operator.operator_code}'},
+        bread_operator,
+        {'name': 'Vehicles', 'url': f'/operator/{bread_operator_slug}/vehicles#{vehicle.fleet_number}-{vehicle.operator.operator_code}'},
         {'name': f'{vehicle.fleet_number} - {vehicle.reg}', 'url': f'/operator/{operator.operator_slug}/vehicles/{vehicle_id}/'}
     ]
 
@@ -2309,9 +2316,15 @@ def log_trip(request, operator_slug, vehicle_id):
     response = feature_enabled(request, "log_trips")
     if response:
         return response
-    
-    operator = get_object_or_404(MBTOperator, operator_slug=operator_slug)
-    vehicle = get_object_or_404(fleet, id=vehicle_id, operator=operator)
+
+    vehicle = get_object_or_404(fleet, id=vehicle_id)
+
+    operator = None
+
+    if vehicle.operator != vehicle.loan_operator:
+        operator = get_object_or_404(MBTOperator, operator_slug=vehicle.loan_operator.operator_slug)
+    else:
+        operator = get_object_or_404(MBTOperator, operator_slug=operator_slug)
 
     userPerms = get_helper_permissions(request.user, operator)
 
@@ -5157,7 +5170,7 @@ def mass_log_trips(request, operator_slug):
     # Load data for GET
     duties = duty.objects.filter(duty_operator=operator, board_type='duty').order_by('duty_name')
     running_boards = duty.objects.filter(duty_operator=operator, board_type='running-boards').order_by('duty_name')
-    vehicles = fleet.objects.filter(operator=operator).order_by('fleet_number')
+    vehicles = fleet.objects.filter(Q(operator=operator ) | Q(loan_operator=operator)).order_by('fleet_number')
     routes = route.objects.filter(route_operators=operator).order_by('route_num')
 
     breadcrumbs = [


### PR DESCRIPTION
Updated vehicle querysets in forms and views to include vehicles where the operator is either the main operator or the loan operator. Adjusted breadcrumb and operator logic in vehicle_detail and log_trip views to correctly handle vehicles on loan.