### PR TITLE
Add mass board assignment and trip logging feature

### DIFF
--- a/fleet/templates/mass_table_log.html
+++ b/fleet/templates/mass_table_log.html
@@ -1,0 +1,197 @@
+{% extends 'mbtbase.html' %}
+{% load static %}
+
+{% block title %}Mass Log Trips - {{ operator.operator_name }}{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'css/narrow.css' %}">
+{% endblock %}
+
+
+{% block content %}
+
+<h2>Mass Log Trips - {{ operator.operator_name }}</h2>
+
+    <!-- GLOBAL BOARD TYPE -->
+    <div class="fleet-edit-wrapper">
+        <label>Global Board Type:</label>
+        <select id="global-board-type">
+            <option value="">(none)</option>
+            <option value="duty">Duty</option>
+            <option value="running">Running Board</option>
+        </select>
+    </div>
+
+    <form method="POST" id="assignForm">
+        {% csrf_token %}
+
+        <!-- DATE -->
+        <div class="fleet-edit-wrapper">
+            <label><strong>Select Date:</strong></label>
+            <input type="date" name="date" id="assign-date" value="{{ current_date }}">
+        </div><br>
+
+        <!-- VEHICLE TABLE -->
+        <div class="table-wrapper">
+            <table class="fleet" border="0" cellpadding="10" cellspacing="0">
+                <thead>
+                    <tr>
+                        <th>Vehicle</th>
+                        <th>Board Type</th>
+                        <th>Duty / Running Board</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for v in vehicles %}
+                    <tr>
+
+                        <td> 
+                            {{ v.fleet_number }} - {{ v.reg }} - {{ v.vehicleType }}
+                        </td>
+
+                        <!-- TYPE -->
+                        <td>
+                            <select 
+                                name="assignments[{{ v.id }}][board_type]"
+                                class="board-type"
+                                data-vehicle="{{ v.id }}"
+                            >
+                                <option value="">Select…</option>
+                                <option value="duty">Duty</option>
+                                <option value="running">Running Board</option>
+                            </select>
+                        </td>
+
+                        <!-- BOARD -->
+                        <td>
+                            <select 
+                                name="assignments[{{ v.id }}][board_id]"
+                                class="board-id"
+                                data-vehicle="{{ v.id }}"
+                            >
+                                <option value="">Select…</option>
+
+                                {% for d in duties %}
+                                <option value="{{ d.id }}" data-type="duty">
+                                    Duty: {{ d.duty_name }}
+                                </option>
+                                {% endfor %}
+
+                                {% for rb in running_boards %}
+                                <option value="{{ rb.id }}" data-type="running">
+                                    RB: {{ rb.duty_name }}
+                                </option>
+                                {% endfor %}
+                            </select>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        <button>Save Assignments</button>
+    </form>
+</div>
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+
+    // -------------------------------
+    // Stable key generator
+    // -------------------------------
+    function getKey(el) {
+
+        if (el.classList.contains("board-type"))
+            return "massassign_vehicle_" + el.dataset.vehicle + "_type";
+
+        if (el.classList.contains("board-id"))
+            return "massassign_vehicle_" + el.dataset.vehicle + "_id";
+
+        if (el.id === "global-board-type")
+            return "massassign_global_type";
+
+        if (el.id === "assign-date")
+            return "massassign_date";
+
+        return "massassign_" + el.id;
+    }
+
+    // -------------------------------
+    // Load saved values
+    // -------------------------------
+    document.querySelectorAll(".board-type, .board-id, #assign-date, #global-board-type")
+        .forEach(el => {
+            const stored = localStorage.getItem(getKey(el));
+            if (stored !== null) el.value = stored;
+        });
+
+    // -------------------------------
+    // Save on change
+    // -------------------------------
+    function saveElement(el) {
+        localStorage.setItem(getKey(el), el.value);
+    }
+
+    document.querySelectorAll(".board-type, .board-id, #assign-date, #global-board-type")
+        .forEach(el => el.addEventListener("change", () => {
+            saveElement(el);
+
+            if (el.id === "global-board-type")
+                applyGlobalBoardType();
+
+            if (el.classList.contains("board-type"))
+                filterBoards(el);
+        }));
+
+    // -------------------------------
+    // Filter duty/running options
+    // -------------------------------
+    function filterBoards(typeSelect) {
+        const vehicle = typeSelect.dataset.vehicle;
+        const type = typeSelect.value;
+
+        const boardSelect = document.querySelector(
+            'select.board-id[data-vehicle="' + vehicle + '"]'
+        );
+
+        boardSelect.querySelectorAll("option").forEach(opt => {
+            if (!opt.dataset.type) return;
+            opt.hidden = (opt.dataset.type !== type);
+        });
+
+        // Reset invalid selection
+        const selected = boardSelect.selectedOptions[0];
+        if (selected && selected.dataset.type !== type) {
+            boardSelect.value = "";
+            saveElement(boardSelect);
+        }
+    }
+
+    // -------------------------------
+    // Apply global type
+    // -------------------------------
+    function applyGlobalBoardType() {
+        const globalType = document.getElementById("global-board-type").value;
+
+        document.querySelectorAll(".board-type").forEach(el => {
+
+            // Only apply if blank OR if user selected a new global type
+            if (!el.value || globalType !== localStorage.getItem(getKey(el))) {
+                el.value = globalType;
+                saveElement(el);
+                filterBoards(el);
+            }
+        });
+    }
+
+    // -------------------------------
+    // Initial load
+    // -------------------------------
+    applyGlobalBoardType();
+    document.querySelectorAll(".board-type").forEach(el => filterBoards(el));
+
+});
+</script>
+
+{% endblock %}

--- a/fleet/urls.py
+++ b/fleet/urls.py
@@ -111,4 +111,5 @@ urlpatterns = [
 
     # Trips
     path('<str:operator_slug>/vehicles/mass-log-trips', mass_log_trips, name='operator_mass_log_trips'),
+    path('<str:operator_slug>/vehicles/mass-assign', mass_assign_boards, name='operator_mass_assign_boards'),
 ]

--- a/fleet/views.py
+++ b/fleet/views.py
@@ -5368,6 +5368,161 @@ def mass_log_trips(request, operator_slug):
 
 @login_required
 @require_http_methods(["GET", "POST"])
+def mass_assign_boards(request, operator_slug):
+    """Assign duties or running boards to multiple vehicles and bulk log trips."""
+    
+    # Feature flag support (if you use it)
+    response = feature_enabled(request, "mass_log_trips")
+    if response:
+        return response
+
+    operator = get_object_or_404(MBTOperator, operator_slug=operator_slug)
+
+    # Permissions
+    userPerms = get_helper_permissions(request.user, operator)
+    if (
+        request.user != operator.owner
+        and 'Mass Log Trips' not in userPerms
+        and not request.user.is_superuser
+    ):
+        messages.error(request, "You do not have permission to log trips for this operator.")
+        return redirect(f'/operator/{operator_slug}/')
+
+    # ----------------------------------------------------------------------
+    # POST: Process all assignments from the table
+    # ----------------------------------------------------------------------
+    if request.method == "POST":
+        date_str = request.POST.get("date")
+        if not date_str:
+            messages.error(request, "A date is required.")
+            return redirect(request.path)
+
+        try:
+            selected_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            messages.error(request, "Invalid date format.")
+            return redirect(request.path)
+
+        # Format:
+        # assignments[123][board_type] = "duty"
+        # assignments[123][board_id] = "52"
+        assignments = {}
+        for key, value in request.POST.items():
+            if key.startswith("assignments["):
+                # assignments[12][board_type]
+                parts = key.split("[")
+                # parts = ["assignments", "12]", "board_type]"]
+
+                if len(parts) != 3:
+                    continue
+
+                vehicle_id = parts[1].replace("]", "")
+                field = parts[2].replace("]", "")
+
+                assignments.setdefault(vehicle_id, {})[field] = value
+
+
+        # Nothing submitted?
+        if not assignments:
+            messages.error(request, "No vehicle assignments found.")
+            return redirect(request.path)
+
+        # Process each vehicle one-by-one
+        for vehicle_id, data in assignments.items():
+            board_type = data.get("board_type")
+            board_id = data.get("board_id")
+
+            # Skip empty rows
+            if not board_type or not board_id:
+                continue
+
+            vehicle = get_object_or_404(fleet, id=vehicle_id)
+
+            # Load duty or running board
+            if board_type == "duty":
+                board_obj = get_object_or_404(
+                    duty,
+                    id=board_id,
+                    board_type="duty",
+                    duty_operator=operator
+                )
+            else:
+                board_obj = get_object_or_404(
+                    duty,
+                    id=board_id,
+                    board_type="running-boards",
+                    duty_operator=operator
+                )
+
+            trip_set = board_obj.duty_trips.all()
+
+            # Create trips for this board
+            for trip in trip_set:
+                start_dt = make_aware(datetime.combine(selected_date, trip.start_time))
+                end_dt = make_aware(datetime.combine(selected_date, trip.end_time))
+
+                created_trip = Trip(
+                    trip_vehicle=vehicle,
+                    trip_route=trip.route_link,
+                    trip_route_num=(
+                        trip.route.route_num
+                        if hasattr(trip.route, "route_num")
+                        else trip.route
+                    ),
+                    trip_start_location=trip.start_at,
+                    trip_end_location=trip.end_at,
+                    trip_start_at=start_dt,
+                    trip_end_at=end_dt,
+                    trip_board=board_obj,
+                )
+
+                try:
+                    created_trip.full_clean()
+                    created_trip.save()
+                except ValidationError as e:
+                    for field, errors in e.message_dict.items():
+                        for error in errors:
+                            messages.error(request, f"Vehicle {vehicle}: {error}")
+                    return redirect(request.path)
+
+        messages.success(request, "All assigned trips logged successfully.")
+        return redirect(request.path)
+
+    # ----------------------------------------------------------------------
+    # GET: Load table
+    # ----------------------------------------------------------------------
+    duties_list = duty.objects.filter(
+        duty_operator=operator, board_type='duty'
+    ).order_by('duty_name')
+
+    running_list = duty.objects.filter(
+        duty_operator=operator, board_type='running-boards'
+    ).order_by('duty_name')
+
+    vehicles = fleet.objects.filter(
+        Q(operator=operator) | Q(loan_operator=operator)
+    ).order_by('fleet_number_sort')
+
+    breadcrumbs = [
+        {'name': 'Home', 'url': '/'},
+        {'name': operator.operator_name, 'url': f'/operator/{operator_slug}/'},
+        {'name': 'Vehicles', 'url': f'/operator/{operator_slug}/vehicles/'},
+        {'name': 'Mass Board Assign', 'url': request.path},
+    ]
+
+    context = {
+        'breadcrumbs': breadcrumbs,
+        'operator': operator,
+        'duties': duties_list,
+        'running_boards': running_list,
+        'vehicles': vehicles,
+        'current_date': timezone.now().strftime("%Y-%m-%d"),
+    }
+    return render(request, 'mass_table_log.html', context)
+
+
+@login_required
+@require_http_methods(["GET", "POST"])
 def route_updates_options(request, operator_slug, route_id):
     route_obj = get_object_or_404(route, id=route_id)
     updates = route_obj.service_updates.all()


### PR DESCRIPTION
Introduces a new view, template, and URL for assigning duties or running boards to multiple vehicles and bulk logging trips. The new 'mass_assign_boards' view handles both GET (table display) and POST (processing assignments), with permission checks and error handling. The 'mass_table_log.html' template provides a user interface for bulk assignment, including localStorage support for form state. Updates to urls.py register the new route.