### PR TITLE
Add route status check page and view

### DIFF
--- a/fleet/templates/route_detail.html
+++ b/fleet/templates/route_detail.html
@@ -137,6 +137,9 @@
     <li><a href="/operator/{{ operator.operator_slug|urlencode }}/route/{{ route.id }}/updates/options">Route Update
             Options</a></li>
     {% endif %}
+    {% if 'owner' in helperPermsData %}
+    <li><a href="/operator/{{ operator.operator_slug|urlencode }}/route/{{ route.id }}/status">Check Trackable Status</a></li>
+    {% endif %}
     {% if user.is_superuser %}<a style="font-size: 14px;" href="/api-admin/routes/route/{{ route.id }}/change/">✎</a>{% endif %}
 </ul>
 

--- a/fleet/templates/route_status.html
+++ b/fleet/templates/route_status.html
@@ -1,0 +1,183 @@
+{% extends 'mbtbase.html' %}
+{% load static %}
+{% load meta_tags %}
+
+{% block extra_meta %}
+    {% meta_description "{{ operator.operator_name }} - Route list" %}
+    {% meta_keywords "routes, route, route list, {{ operator.operator_name }}" %}
+    {% meta_title "{{ operator.operator_name }} - Route List" %}
+    {% meta_url "https://www.mybustimes.cc/operator/{{ operator.operator_slug }}/" %}
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'css/narrow.css' %}">
+<style>
+    .status-card {
+        border: 1px solid var(--border-color);
+        padding: 15px;
+        border-radius: 6px;
+        background: var(--background-color);
+        margin-bottom: 15px;
+        color: var(--text-color);
+    }
+
+    .status-card h2,
+    .status-card h3 {
+        margin-top: 0;
+        color: var(--text-color);
+    }
+
+    .status-pill {
+        display: inline-block;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 12px;
+        color: #fff;
+    }
+
+    .pill-ok { background: #2ecc71; }
+    .pill-warn { background: #f1c40f; }
+    .pill-bad { background: #e74c3c; }
+    .pill-info { background: #3498db; }
+    .pill-neutral { background: #95a5a6; }
+
+    .status-warning {
+        border: 1px solid var(--brand-color);
+        background: var(--brand-color-darker);
+        padding: 10px;
+        border-radius: 4px;
+        color: var(--text-color);
+        margin-bottom: 15px;
+    }
+
+    /* Table layout */
+    .status-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 10px;
+        background: var(--background-color);
+        color: var(--text-color);
+        border: 1px solid var(--border-color-darker);
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    .status-table th,
+    .status-table td {
+        padding: 8px 10px;
+        border-bottom: 1px solid var(--border-color);
+        text-align: left;
+    }
+
+    .status-table th {
+        background: var(--brand-color-darker);
+        color: #fff;
+        font-weight: bold;
+    }
+
+    .status-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    .yes-cell { color: #2ecc71; font-weight: bold; }
+    .no-cell { color: #e74c3c; font-weight: bold; }
+</style>
+
+{% endblock %}
+
+{% block title %}{{ operator.operator_name }}{% endblock %}
+
+{% block content %}
+<script>
+    window.statusReport = {{ status_report_json|safe }};
+</script>
+<br>
+<div id="statusBox"></div>
+
+<script>
+const status = window.statusReport;
+
+function pill(text, cls) {
+    return `<span class="status-pill ${cls}">${text}</span>`;
+}
+
+function yesNo(val) {
+    return val
+        ? `<span class="yes-cell">Yes</span>`
+        : `<span class="no-cell">No</span>`;
+}
+
+function renderStatus(status) {
+    const isCircular = status.is_circular === true;
+
+    function statusClass(state) {
+        if (state === "Ok") return "pill-ok";
+        if (state === "Missing Stops") return "pill-warn";
+        if (state === "No Timetable") return "pill-bad";
+        return "pill-neutral";
+    }
+
+    const missingOutbound =
+        !status.all.outbound.has_timetable &&
+        !status.all.outbound.has_stops;
+
+    // SUMMARY CARD
+    let html = `
+        <div class="status-card">
+            <h2>Route Status Summary</h2>
+
+            <p><strong>Inbound:</strong>
+                ${pill(status.inbound, statusClass(status.inbound))}
+            </p>
+
+            <p><strong>Outbound:</strong>
+                ${isCircular 
+                    ? pill("Circular Route - No Outbound", "pill-info")
+                    : pill(status.outbound, statusClass(status.outbound))
+                }
+            </p>
+
+            <p><strong>Overall:</strong>
+                ${pill(status.overall, statusClass(status.overall))}
+            </p>
+        </div>
+    `;
+
+    // WARNING
+    if (!isCircular && missingOutbound) {
+        html += `
+            <div class="status-warning">
+                <strong>Warning:</strong> This route is missing all outbound timetable and stop data.
+            </div>
+        `;
+    }
+
+    // TABLES
+    html += `
+        <div class="status-card">
+            <h3>Inbound Data</h3>
+            <table class="status-table">
+                <tr><th>Has Timetable</th><td>${yesNo(status.all.inbound.has_timetable)}</td></tr>
+                <tr><th>Has Stops</th><td>${yesNo(status.all.inbound.has_stops)}</td></tr>
+                <tr><th>Fully Valid</th><td>${yesNo(status.all.overall.inbound)}</td></tr>
+            </table>
+        </div>
+
+        <div class="status-card">
+            <h3>Outbound Data</h3>
+            <table class="status-table">
+                <tr><th>Has Timetable</th><td>${yesNo(status.all.outbound.has_timetable)}</td></tr>
+                <tr><th>Has Stops</th><td>${yesNo(status.all.outbound.has_stops)}</td></tr>
+                <tr><th>Fully Valid</th><td>${yesNo(status.all.overall.outbound)}</td></tr>
+            </table>
+        </div>
+    `;
+
+    document.getElementById("statusBox").innerHTML = html;
+}
+
+renderStatus(status);
+</script>
+
+{% endblock %}
+

--- a/fleet/urls.py
+++ b/fleet/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     path('<str:operator_slug>/route/<int:route_id>/edit/', route_edit, name='edit-route'),
     path('<str:operator_slug>/route/<int:route_id>/delete/', route_delete, name='delete-route'),
     path("<str:operator_slug>/route/<int:route_id>/vehicles/", route_vehicles, name="route_vehicles"),
+    path('<str:operator_slug>/route/<int:route_id>/status/', trackable_status, name='trackable_status'),
     path('<str:operator_slug>/routes/dedupe', deduplicate_operator_routes, name='deduplicate_routes'),
 
     # Route Updates

--- a/fleet/views.py
+++ b/fleet/views.py
@@ -750,6 +750,94 @@ def route_detail(request, operator_slug, route_id):
 
     return render(request, 'route_detail.html', context)
 
+def trackable_status(request, operator_slug, route_id):
+    response = feature_enabled(request, "view_routes")
+    if response:
+        return response
+
+    operator = get_object_or_404(MBTOperator, operator_slug=operator_slug)
+    route_instance = get_object_or_404(route, id=route_id)
+
+    inbound_timetable_entries = timetableEntry.objects.filter(route=route_instance, inbound=True)
+    outbound_timetable_entries = timetableEntry.objects.filter(route=route_instance, inbound=False)
+
+    inbound_route_stops = routeStop.objects.filter(route=route_instance, inbound=True).first()
+    outbound_route_stops = routeStop.objects.filter(route=route_instance, inbound=False).first()
+
+    # circular route = no outbound direction
+    is_circular = False
+    if route_instance.outbound_destination == "":
+        is_circular = True
+
+    has_in_timetable = inbound_timetable_entries.exists()
+    has_out_timetable = outbound_timetable_entries.exists()
+    has_in_stops = inbound_route_stops is not None
+    has_out_stops = outbound_route_stops is not None
+
+    # Inbound status
+    if has_in_timetable and has_in_stops:
+        inbound_status = "Ok"
+    elif has_in_timetable and not has_in_stops:
+        inbound_status = "Missing Stops"
+    else:
+        inbound_status = "No Timetable"
+
+    # Outbound status
+    if is_circular:
+        outbound_status = "Circular (no outbound)"
+    else:
+        if has_out_timetable and has_out_stops:
+            outbound_status = "Ok"
+        elif has_out_timetable and not has_out_stops:
+            outbound_status = "Missing Stops"
+        else:
+            outbound_status = "No Timetable"
+
+    # Overall
+    if inbound_status == "Ok" and outbound_status == "Ok":
+        overall_status = "Ok"
+    elif inbound_status == "Ok" and outbound_status != "Ok":
+        overall_status = "Missing Outbound Data"
+    elif inbound_status != "Ok" and outbound_status == "Ok":
+        overall_status = "Missing Inbound Data"
+    else:
+        overall_status = "Incomplete"
+
+    status_report = {
+        'inbound': inbound_status,
+        'outbound': outbound_status,
+        'overall': overall_status,
+        'is_circular': is_circular,
+        'all': {
+            'inbound': {
+                'has_timetable': has_in_timetable,
+                'has_stops': has_in_stops
+            },
+            'outbound': {
+                'has_timetable': has_out_timetable,
+                'has_stops': has_out_stops
+            },
+            'overall': {
+                'inbound': has_in_timetable and has_in_stops,
+                'outbound': has_out_timetable and has_out_stops
+            }
+        }
+    }
+
+    breadcrumbs = [
+        {'name': 'Home', 'url': '/'},
+        {'name': operator.operator_name, 'url': f'/operator/{operator.operator_slug}/'},
+        {'name': route_instance.route_num or 'Route Details', 'url': f'/operator/{operator.operator_slug}/route/{route_id}/'}
+    ]
+
+    context = {
+        'breadcrumbs': breadcrumbs,
+        'operator': operator,
+        'status_report_json': json.dumps(status_report)  # send to JS
+    }
+
+    return render(request, 'route_status.html', context)
+
 def vehicles(request, operator_slug, depot=None, withdrawn=False):
     operator = get_object_or_404(MBTOperator, operator_slug=operator_slug)
 


### PR DESCRIPTION
Introduces a new 'Check Trackable Status' link for route owners in the route detail page. Adds a new route_status.html template and a trackable_status view to display the completeness of timetable and stop data for inbound and outbound directions, including handling for circular routes. Updates URLs to include the new status endpoint.