### PR TITLE
Add snapped route geometry support for bus routes

### DIFF
--- a/fleet/templates/route_add_route.html
+++ b/fleet/templates/route_add_route.html
@@ -379,27 +379,53 @@
 
   // Save button
   document.getElementById("submitRoute").addEventListener("click", () => {
-    const rows = stopList.querySelectorAll("tr");
+      const rows = stopList.querySelectorAll("tr");
 
-    const formattedStops = Array.from(rows).map((row, i) => {
-        const s = selectedCoords[i];
-        const timing = row.querySelector("input[type=checkbox]")?.checked || false;
-        return {
-            stop: selectedStops[i],
-            cords: `${s.lat},${s.lon}`,
-            timing_point: timing,
-            distance_m: cumulativeDistance,
-            time_s: cumulativeTime
-        };
-    });
+      // --- REBUILD DISTANCE/TIME (fixes cumulativeDistance missing bug) ---
+      let cumulativeDistance = 0;
+      let cumulativeTime = 0;
 
-    const payload = {
-        stops: formattedStops,
-        snapped_geometry: window.snappedFullGeometry || []
-    };
+      const segmentInfo = [];
+      for (let i = 0; i < selectedCoords.length - 1; i++) {
+          const a = [selectedCoords[i].lon, selectedCoords[i].lat];
+          const b = [selectedCoords[i+1].lon, selectedCoords[i+1].lat];
 
-    document.getElementById("routeDataInput").value = JSON.stringify(payload);
-    document.getElementById("routeForm").submit();
+          // fallback distance
+          const dist = Math.round(haversineDistance(a, b));
+          const assumedSpeed = 8.333333; // 30 km/h
+          const t = Math.round(dist / assumedSpeed);
+
+          segmentInfo[i] = { distance: dist, time: t };
+      }
+      // -------------------------------------------------------------------
+
+      const formattedStops = Array.from(rows).map((row, i) => {
+          const s = selectedCoords[i];
+          const timing = row.querySelector("input[type=checkbox]")?.checked || false;
+
+          // increment for all except first stop
+          if (i > 0) {
+              cumulativeDistance += segmentInfo[i - 1].distance;
+              cumulativeTime += segmentInfo[i - 1].time;
+          }
+
+          return {
+              stop: selectedStops[i],
+              cords: `${s.lat},${s.lon}`,
+              timing_point: timing,
+              distance_m: cumulativeDistance,
+              time_s: cumulativeTime
+          };
+      });
+
+      const payload = {
+          stops: formattedStops,
+          snapped_geometry: window.snappedFullGeometry || []
+      };
+
+      document.getElementById("routeDataInput").value = JSON.stringify(payload);
+      document.getElementById("routeForm").submit();
   });
+
 </script>
 {% endblock %}

--- a/fleet/templates/timetable_add.html
+++ b/fleet/templates/timetable_add.html
@@ -48,6 +48,11 @@
     <button type="button" onclick="autoFillOffsets()">Auto Fill Offsets</button>
   </div>
 
+  <div>
+    <button type="button" onclick="autoFillFromStops()">Auto Fill From Stop Data</button>
+    <small>Uses <code>time_s</code> offsets from your routeStop JSON</small>
+  </div>
+
   <br>
 
   <table style="width: 100%;">
@@ -60,7 +65,7 @@
     </thead>
     <tbody>
       {% for stop in stops.stops %}
-      <tr data-stopname="{{ stop.stop }}" data-order="{{ forloop.counter0 }}">
+      <tr data-stopname="{{ stop.stop }}" data-order="{{ forloop.counter0 }}" data-times="{{ stop.time_s }}">
         <td>
           {{ stop.stop }}
           <input type="hidden" name="stop_names" value="{{ stop.stop }}">
@@ -87,6 +92,64 @@
 </form>
 
 <script>
+  function autoFillFromStops() {
+    // Grab all rows with stop data
+    const rows = document.querySelectorAll("tbody tr");
+    let prevOffset = null;
+    let prevTime = null;
+
+    console.log("=== Auto Fill From Stop Data ===");
+
+    rows.forEach((row, i) => {
+        const time_s = parseInt(row.dataset.times, 10);
+        const offsetInput = row.querySelector(".offset-minutes");
+
+        console.log("\n-----------------------------------------");
+        console.log(`STOP ${i}: ${row.dataset.stopname}`);
+        console.log(`time_s = ${time_s}`);
+
+        // FIRST STOP
+        if (i === 0) {
+            console.log("First stop → offset = 0 (no field to write)");
+            prevOffset = 0;
+            prevTime = time_s;
+            return;
+        }
+
+        // Raw diff from previous stop
+        const raw = time_s - prevTime;
+        console.log(`raw diff from prev = ${raw} sec`);
+
+        let offset;
+
+        if (raw >= 30) {
+            // More than 30s: convert to minutes
+            offset = Math.round(raw / 60);
+            console.log(`>= 30s → offset = round(${raw}/60) = ${offset}`);
+        } else {
+            // Less than 30s → zero
+            offset = 0;
+            console.log(`< 30s → offset = 0`);
+        }
+
+        // RULE: no two zeros in a row
+        if (offset === 0 && prevOffset === 0) {
+            console.log("Two-zero rule triggered → converting 0 → 1");
+            offset = 1;
+        }
+
+        console.log(`FINAL offset = ${offset}`);
+
+        // Write into the table form input
+        offsetInput.value = offset;
+
+        prevOffset = offset;
+        prevTime = time_s;
+    });
+
+    // Regenerate JSON after all updates
+    generateStopTimesJSON();
+}
 function generateStopTimesJSON() {
   const rows = document.querySelectorAll('tbody tr');
   const output = {}; // dict keyed by index

--- a/tracking/views.py
+++ b/tracking/views.py
@@ -280,22 +280,53 @@ class current_vehicle_trips(generics.ListAPIView):
         print(f"[DEBUG] current_vehicle_trips: found {queryset.count()} trips")
         return queryset
     
+def get_snapped_coords(rs):
+    """
+    Parse rs.snapped_route (JSON text) → list[(lat,lng)]
+    DB format is [[lng,lat], ...] so flip to (lat,lng).
+    """
+    if not rs.snapped_route:
+        return None
+
+    try:
+        data = json.loads(rs.snapped_route)
+        coords = []
+        for pair in data:
+            if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+                continue
+            lng, lat = pair
+            coords.append((float(lat), float(lng)))
+        return coords if coords else None
+    except:
+        return None
+    
 def calculate_heading(lat1, lng1, lat2, lng2):
     """
     Returns heading in degrees (0–360),
     where 0 = North, 90 = East, 180 = South, 270 = West.
+    Handles identical or near-identical points safely.
     """
-    lat1 = math.radians(lat1)
-    lat2 = math.radians(lat2)
+
+    # If no movement → return 0 (or keep last heading outside this function)
+    if abs(lat1 - lat2) < 1e-9 and abs(lng1 - lng2) < 1e-9:
+        return 0.0
+
+    # Convert to radians
+    lat1_rad = math.radians(lat1)
+    lat2_rad = math.radians(lat2)
     d_lng = math.radians(lng2 - lng1)
 
-    x = math.sin(d_lng) * math.cos(lat2)
-    y = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(d_lng)
+    # Standard great-circle bearing
+    x = math.sin(d_lng) * math.cos(lat2_rad)
+    y = math.cos(lat1_rad) * math.sin(lat2_rad) - \
+        math.sin(lat1_rad) * math.cos(lat2_rad) * math.cos(d_lng)
 
     heading = math.degrees(math.atan2(x, y))
-    heading = (heading + 360) % 360
-    return heading
 
+    # Normalise 0–360
+    heading = (heading + 360) % 360
+
+    return heading
 def get_route_coordinates(route_id, trip):
     """
     Determine which routeStop direction to use.
@@ -361,12 +392,20 @@ def get_route_coordinates(route_id, trip):
 
 
 def extract_coords_from_routeStop(rs):
-    """Small helper that extracts coords only (in one list)."""
+    # Prefer snapped route if present
+    snapped = get_snapped_coords(rs)
+    if snapped:
+        return snapped
+
     coords, _ = extract_coords_and_last_stop(rs)
     return coords or []
 
 
 def extract_coords_and_last_stop(rs):
+    # Prefer snapped route if present
+    snapped = get_snapped_coords(rs)
+    if snapped:
+        return snapped, None
     """Shared logic from your old loop."""
     coords = []
     last_stop_name = None


### PR DESCRIPTION
Fixes cumulative distance/time calculation bug in route_add_route.html by rebuilding segment info before payload creation. Adds 'Auto Fill From Stop Data' feature to timetable_add.html for offset calculation based on stop time_s values. Refactors tracking/views.py to prefer snapped route coordinates and improves heading calculation robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Auto Fill From Stop Data" button to auto-populate timetable offsets from stop information.

* **Bug Fixes**
  * Fixed distance and time calculation in route saving to properly accumulate values per segment.
  * Improved coordinate extraction and bearing calculations for more accurate location handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->