### PR TITLE
Show vehicle tracking count on Map tab

### DIFF
--- a/fleet/templates/operator.html
+++ b/fleet/templates/operator.html
@@ -167,4 +167,32 @@
     </div>
   </dl>
 </div>
+
+<script>
+    async function getTrackingCount() {
+        console.log("Getting tracking count...");
+       
+        let routeId = "{{ route.id }}";
+        const url = `http://localhost:8000/api/trips/simulated_positions/?ymax=85.05112900000006&ymin=-85.05112900000005&xmax=297.19191775256854&xmin=-172.38929421782453&route_id=${routeId}&limit=5000`;
+        
+        const res = await fetch(url);
+
+        console.log("Fetched URL:", url);
+
+        const data = await res.json();
+
+        const count = data.count || 0;
+
+        const mapBT = document.getElementById('Map');
+        if (count > 0) {
+            mapBT.textContent = `Map (tracking ${count} vehicle${count !== 1 ? 's' : ''})`;
+        } else {
+            mapBT.textContent = 'Map';
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        getTrackingCount();
+    });
+</script>
 {% endblock %}

--- a/fleet/templates/partials/tabs.html
+++ b/fleet/templates/partials/tabs.html
@@ -89,7 +89,7 @@
     {% if tab.active %}
     {{ tab.name }}
     {% else %}
-    <a href="{{ tab.url }}">{{ tab.name }}</a>
+    <a href="{{ tab.url }}" id="{{ tab.name }}">{{ tab.name }}</a>
     {% endif %}
   </li>
   {% endfor %}

--- a/fleet/templates/route_detail.html
+++ b/fleet/templates/route_detail.html
@@ -133,7 +133,6 @@
 <p>This service is <strong>not</strong> for general public use.</p>
 {% endif %}
 
-
 <ul class="horizontal">
     {% if 'Edit Routes' in helperPermsData or 'owner' in helperPermsData %}
     <li><a href="/operator/{{ operator.operator_slug|urlencode }}/route/{{ route.id }}/edit">Route Options</a></li>
@@ -235,7 +234,7 @@
 
 <ul class="tabs">
     <li class="active">Timetable</li>
-    <li class=""><a href="/map/route/{{ route.id }}/">Map</a></li>
+    <li class=""><a href="/map/route/{{ route.id }}/" id="mapBT">Map</a></li>
     <li class=""><a href="vehicles">Vehicles</a></li>
 </ul>
 
@@ -420,7 +419,30 @@
 </div>
 
 <script>
+    async function getTrackingCount() {
+        console.log("Getting tracking count...");
+       
+        let routeId = "{{ route.id }}";
+        const url = `http://localhost:8000/api/trips/simulated_positions/?ymax=85.05112900000006&ymin=-85.05112900000005&xmax=297.19191775256854&xmin=-172.38929421782453&route_id=${routeId}&limit=5000`;
+        
+        const res = await fetch(url);
+
+        console.log("Fetched URL:", url);
+
+        const data = await res.json();
+
+        const count = data.count || 0;
+
+        const mapBT = document.getElementById('mapBT');
+        if (count > 0) {
+            mapBT.textContent = `Map (tracking ${count} vehicle${count !== 1 ? 's' : ''})`;
+        } else {
+            mapBT.textContent = 'Map';
+        }
+    }
+
     document.addEventListener("DOMContentLoaded", function () {
+        getTrackingCount();
         const hash = window.location.hash.substring(1); // remove the '#'
         if (!hash) return;
 


### PR DESCRIPTION
Added JavaScript to fetch and display the number of tracked vehicles on the Map tab in both operator and route detail pages. Updated tab elements to have unique IDs for dynamic text updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map tabs now display real-time tracking vehicle counts across multiple route views, with labels that dynamically update to show the number of active tracked vehicles (e.g., "Map (tracking 5 vehicles)"). This provides operators with instant visibility into tracking status.

* **Style**
  * Enhanced tab navigation elements with unique identifiers for improved interface interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->