### PR TITLE
Add board info to route vehicles view and template

### DIFF
--- a/fleet/templates/route_vehicles.html
+++ b/fleet/templates/route_vehicles.html
@@ -38,6 +38,15 @@
                 <td>{% if vehicle.trip_display_id %}{{ vehicle.trip_display_id }}{% else %}{{ vehicle.pk }}{% endif %}</td>
                 <td><a href="/map/trip/{{ vehicle.trip_id }}/">{{ vehicle.trip_start_at | date:"H:i" }}</a></td>
                 <td>{{ vehicle.trip_end_location }}</td>
+                {% if show_board %}
+                    {% if trip.trip_board.board_type == "duty" %}
+                        <td><a href="/operator/{{ operator.operator_slug }}/duty/{{ trip.trip_board.id }}/">{{ trip.trip_board.duty_name }}</a></td>
+                    {% elif trip.trip_board.board_type == "running-boards" %}
+                        <td><a href="/operator/{{ operator.operator_slug }}/running-boards/{{ trip.trip_board.id }}/">{{ trip.trip_board.duty_name }}</a></td>
+                    {% else %}
+                        <td></td>
+                    {% endif %}
+                {% endif %}
                 <td><a href="/map/trip/{{ vehicle.trip_id }}/">Map</a></td>
                 {% if user.is_superuser %}<td><a style="font-size: 14px;" href="/api-admin/tracking/trip/{{ vehicle.trip_id }}/change/">✎</a></td>{% endif %}
             </tr>

--- a/fleet/views.py
+++ b/fleet/views.py
@@ -480,6 +480,7 @@ def route_vehicles(request, operator_slug, route_id):
         'vehicles': vehicles,
         'operator': operator,
         'route': route_instance,
+        'show_board': any(t.trip_board for t in vehicles),
         'breadcrumbs': breadcrumbs,
         'date': date,
         'now': now


### PR DESCRIPTION
Display board details in the route vehicles table if available. Updated the view to pass a 'show_board' flag to the template, enabling conditional rendering of board links based on trip board type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added board/trip summary column to the Vehicles table, displaying links to relevant board pages with corresponding board names when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->