### PR TITLE
Show relative time for vehicle updates on maps

### DIFF
--- a/fleet/templates/route_map.html
+++ b/fleet/templates/route_map.html
@@ -310,7 +310,7 @@ setInterval(loadOperatorBT, 30000);
 
 function timeAgo(dateString) {
     if (!dateString) return '';
-    const seconds = Math.floor((new Date() - new Date(dateString)) / 5000);
+    const seconds = Math.floor((new Date() - new Date(dateString)) / 1000);
     if (seconds < 60) return `${seconds} sec${seconds !== 1 ? 's' : ''} ago`;
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) return `${minutes} min${minutes !== 1 ? 's' : ''} ago`;

--- a/main/templates/map-operator.html
+++ b/main/templates/map-operator.html
@@ -334,7 +334,7 @@ setInterval(loadOperatorBT, 30000);
 
 function timeAgo(dateString) {
     if (!dateString) return '';
-    const seconds = Math.floor((new Date() - new Date(dateString)) / 5000);
+    const seconds = Math.floor((new Date() - new Date(dateString)) / 1000);
     if (seconds < 60) return `${seconds} sec${seconds !== 1 ? 's' : ''} ago`;
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) return `${minutes} min${minutes !== 1 ? 's' : ''} ago`;

--- a/main/templates/map.html
+++ b/main/templates/map.html
@@ -111,7 +111,7 @@
 
   function timeAgo(dateString) {
     if (!dateString) return '';
-    const seconds = Math.floor((new Date() - new Date(dateString)) / 5000);
+    const seconds = Math.floor((new Date() - new Date(dateString)) / 1000);
     if (seconds < 60) return `${seconds} sec${seconds !== 1 ? 's' : ''} ago`;
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) return `${minutes} min${minutes !== 1 ? 's' : ''} ago`;

--- a/main/templates/trip_map.html
+++ b/main/templates/trip_map.html
@@ -77,7 +77,7 @@
 
 <script>
   const tripId = "{{ trip.trip_id }}";   // ensure string interpolation
-  const vehicleId = "{{ trip.vehicle.vehicle_id|default:'' }}";
+  const vehicleId = "{{ trip.trip_vehicle.id|default:'' }}";
   let btMarkers = [];
   let currentDirection = "inbound";
 
@@ -283,7 +283,7 @@ setInterval(loadOperatorBT, 30000);
 
 function timeAgo(dateString) {
     if (!dateString) return '';
-    const seconds = Math.floor((new Date() - new Date(dateString)) / 5000);
+    const seconds = Math.floor((new Date() - new Date(dateString)) / 1000);
     if (seconds < 60) return `${seconds} sec${seconds !== 1 ? 's' : ''} ago`;
     const minutes = Math.floor(seconds / 60);
     if (minutes < 60) return `${minutes} min${minutes !== 1 ? 's' : ''} ago`;


### PR DESCRIPTION
Corrects the timeAgo function in multiple templates to use a 1-second interval instead of 5 seconds for more accurate time display. Also updates the vehicleId reference in trip_map.html to use trip.trip_vehicle.id instead of trip.vehicle.vehicle_id.