### PR TITLE
Update FleetAdmin and trip simulation logic

### DIFF
--- a/fleet/admin.py
+++ b/fleet/admin.py
@@ -310,7 +310,7 @@ class FleetAdmin(SimpleHistoryAdmin):
         FleetOperatorFilter,
         FleetLiveryFilter,
     )
-    autocomplete_fields = ["operator", "loan_operator", "livery", "vehicleType", "last_modified_by"]
+    autocomplete_fields = ["operator", "loan_operator", "livery", "vehicleType", "last_modified_by", "current_trip"]
     actions = [
         deduplicate_fleet,
         mark_as_for_sale,

--- a/tracking/management/commands/simulate_positions.py
+++ b/tracking/management/commands/simulate_positions.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         # 2. Clear sim data for vehicles not on active trips
         # ---------------------------------------------------------
         fleet.objects.filter(
-            current_trip__trip_end_at__lt=now
+            current_trip__trip_end_at__lt=now + timezone.timedelta(minutes=15)
         ).update(
             sim_lat=None,
             sim_lon=None,


### PR DESCRIPTION
Added 'current_trip' to FleetAdmin autocomplete fields for improved admin usability. Adjusted simulate_positions command to clear sim data for vehicles with trips ending within the next 15 minutes, instead of only those with trips already ended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced admin interface autocomplete functionality for fleet management
  * Adjusted simulation data cleanup window to retain data for an additional 15 minutes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->