### PR TITLE
Add trip tracking push API and UI improvements

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     #path("trips/simulated_positions/", ratelimit(key='ip', method='GET', rate='10/s')(VehiclePositionAPIView.as_view()), name="estimated-positions"),
     path("trips/simulated_positions/", ratelimit(key='ip', method='GET', rate='10/s')(trackingAPIView.as_view()), name="simulated-positions"),
     path("trips/vehicle/<int:vehicle_id>/simulate/", ratelimit(key='ip', method='POST', rate='30/m')(push_sim_position), name="push_sim_position"),
+    path("trips/<int:trip_id>/tracking/", ratelimit(key='ip', method='POST', rate='30/m')(push_trip_position), name="push-trip-position"),
     path("trips/<int:trip_id>/", ratelimit(key='ip', method='GET', rate='10/s')(TripDetailView.as_view()), name="trip-detail"),
 
     path("tracking/", ratelimit(key='ip', method='GET', rate='10/s')(TrackingListView.as_view()), name="tracking-list"),

--- a/docs/api_push_sim_position.md
+++ b/docs/api_push_sim_position.md
@@ -1,0 +1,192 @@
+# Simulated Position Push API
+
+Pushes a simulated GPS position (latitude / longitude / rotation) onto a single vehicle — used by the tracking/simulation systems and external ticketer devices to report where a vehicle is.
+
+- **Endpoint:** `POST /api/trips/vehicle/<vehicle_id>/simulate/`
+- **Rate limit:** 30 requests per minute per IP
+- **Auth:** Session key (ticketer-code system) — see below
+- **Base URL note:** paths below are relative to the site root (e.g. `https://yourdomain.com/api/trips/vehicle/123/simulate/`)
+
+---
+
+## 1. Authentication
+
+The endpoint uses the same session-key mechanism as the ticketer code system. You must first log in to obtain a session key, then send that key on every request.
+
+### 1a. Get a session key
+
+`POST /api/user/`
+
+Login using either of these JSON body shapes:
+
+**Option A — user ID + ticketer code:**
+
+```json
+{
+  "user_id": 1,
+  "code": "123456"
+}
+```
+
+**Option B — username + password:**
+
+```json
+{
+  "username": "ej",
+  "password": "hunter2"
+}
+```
+
+**Response (200):**
+
+```json
+{
+  "id": 1,
+  "username": "ej",
+  "ticketer_code": "123456",
+  "session_key": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+}
+```
+
+Note: issuing a new `get_user_profile` call deletes all previous session keys for that user and generates a fresh one.
+
+### 1b. Send the session key
+
+Every request to the simulate endpoint needs the session key, supplied either:
+
+- as the JSON field `session_key`, or
+- as an `Authorization` header: `Authorization: SessionKey <key>`
+
+---
+
+## 2. Request
+
+### URL
+```
+POST /api/trips/vehicle/<vehicle_id>/simulate/
+```
+
+`vehicle_id` is the numeric vehicle ID (seen in the address bar of the vehicle edit page, e.g. `https://yourdomain.com/operator/<slug>/vehicle/edit/171541/`).
+
+### Headers
+```
+Content-Type: application/json
+Authorization: SessionKey 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+```
+
+### Body (JSON)
+
+| Field       | Type    | Required | Description                                       |
+|-------------|---------|----------|---------------------------------------------------|
+| `lat`       | number  | Yes      | Latitude, between `-90` and `90`                  |
+| `lon`       | number  | Yes      | Longitude, between `-180` and `180`               |
+| `rotation`  | number  | No       | Compass heading in degrees, between `0` and `360`. Omitted → keeps the vehicle's current `sim_heading` |
+| `vehicle_id`| int     | No       | Alternative to the URL path (`vehicle_id` in URL wins) |
+| `session_key`| string | No      | Alternative to the `Authorization` header          |
+
+**Example:**
+```json
+{
+  "lat": 52.630886,
+  "lon": -2.460367,
+  "rotation": 124.5
+}
+```
+
+---
+
+## 3. Response
+
+**Success (200):**
+```json
+{
+  "success": true,
+  "vehicle_id": 171541,
+  "lat": 52.630886,
+  "lon": -2.460367,
+  "rotation": 124.5,
+  "updated_at": "2026-08-11T14:23:45.123456+00:00"
+}
+```
+
+The vehicle's `sim_lat`, `sim_lon`, `sim_heading` and `updated_at` fields are updated and saved.
+
+---
+
+## 4. Errors
+
+| Status | Body `error`                          | When                                            |
+|--------|---------------------------------------|-------------------------------------------------|
+| 405    | `Only POST method is allowed`         | Non-POST request                               |
+| 400    | `Invalid JSON`                        | Body is not valid JSON                          |
+| 400    | `Missing vehicle_id`                  | No ID in URL or body                            |
+| 401    | `Missing session_key`                 | No session key supplied                         |
+| 401    | `Invalid session key`                 | Session key does not match any `UserKeys` row   |
+| 403    | `Permission denied`                   | User does not own the vehicle's operator (or loan operator) |
+| 404    | `Vehicle not found`                   | Vehicle ID does not exist                       |
+| 400    | `lat and lon are required numeric fields` | `lat`/`lon` missing or not numeric           |
+| 400    | `lat must be between -90 and 90`      | Latitude out of range                           |
+| 400    | `lon must be between -180 and 180`    | Longitude out of range                          |
+| 400    | `rotation must be numeric`            | Rotation not numeric                            |
+| 400    | `rotation must be between 0 and 360`  | Rotation out of range                           |
+
+---
+
+## 5. Permissions
+
+Only the owner of the operator a vehicle belongs to **or** is loaned to may push a position:
+
+- `vehicle.operator.owner == user` → allowed
+- `vehicle.loan_operator.owner == user` → allowed
+- otherwise → `403 Permission denied`
+
+---
+
+## 6. Example: curl
+
+```bash
+# 1. Log in and grab the session key
+curl -X POST https://yourdomain.com/api/user/ \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1, "code": "123456"}'
+
+# 2. Push a position using the Authorization header
+curl -X POST https://yourdomain.com/api/trips/vehicle/171541/simulate/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: SessionKey 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" \
+  -d '{"lat": 52.630886, "lon": -2.460367, "rotation": 124.5}'
+```
+
+---
+
+## 7. Example: Python
+
+```python
+import requests
+
+BASE = "https://yourdomain.com"
+
+# 1. Log in
+r = requests.post(f"{BASE}/api/user/", json={"user_id": 1, "code": "123456"})
+r.raise_for_status()
+key = r.json()["session_key"]
+
+# 2. Push a position
+r = requests.post(
+    f"{BASE}/api/trips/vehicle/171541/simulate/",
+    headers={"Content-Type": "application/json",
+             "Authorization": f"SessionKey {key}"},
+    json={"lat": 52.630886, "lon": -2.460367, "rotation": 124.5},
+)
+print(r.status_code, r.json())
+```
+
+---
+
+## 8. Implementation reference
+
+- View: `tracking/views.py` → `push_sim_position`
+- URL: `api/urls.py` line 69, name `push_sim_position`, wrapped in `ratelimit(key='ip', method='POST', rate='30/m')`
+- Session key storage: `main/models.py` → `UserKeys`
+- Login helper: `main/views.py` → `get_user_profile` (registered as `GET /api/user/` in `api/urls.py`; the view itself only accepts `POST`)
+- Fields written on the vehicle (`fleet` model): `sim_lat`, `sim_lon`, `sim_heading`, `updated_at`

--- a/fleet/templates/add.html
+++ b/fleet/templates/add.html
@@ -228,8 +228,11 @@
       <div class="field-row" id="length-row">
         <div class="field-body">
           <span class="field-label" id="length-label">Length</span>
-          <input type="text" id="length" name="length" list="length-datalist" value="{{ fleetData.length|default_if_none:'' }}" placeholder="Select or type a length...">
-          <datalist id="length-datalist"></datalist>
+          <select id="length-select" style="display:none;">
+            <option value="">Select a length...</option>
+          </select>
+          <input type="text" id="length-manual" style="display:none;" placeholder="Custom length">
+          <input type="hidden" id="length" name="length" value="{{ fleetData.length|default_if_none:'' }}">
           <div id="length-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -237,8 +240,11 @@
       <div class="field-row" id="engine-row">
         <div class="field-body">
           <span class="field-label">Engine</span>
-          <input type="text" id="engine" name="engine" list="engine-datalist" value="{{ fleetData.engine }}" placeholder="Select or type an engine...">
-          <datalist id="engine-datalist"></datalist>
+          <select id="engine-select" style="display:none;">
+            <option value="">Select an engine...</option>
+          </select>
+          <input type="text" id="engine-manual" style="display:none;" placeholder="Custom engine">
+          <input type="hidden" id="engine" name="engine" value="{{ fleetData.engine }}">
           <div id="engine-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -246,8 +252,11 @@
       <div class="field-row" id="gearbox-row">
         <div class="field-body">
           <span class="field-label">Gearbox</span>
-          <input type="text" id="gearbox" name="gearbox" list="gearbox-datalist" value="{{ fleetData.gearbox }}" placeholder="Select or type a gearbox...">
-          <datalist id="gearbox-datalist"></datalist>
+          <select id="gearbox-select" style="display:none;">
+            <option value="">Select a gearbox...</option>
+          </select>
+          <input type="text" id="gearbox-manual" style="display:none;" placeholder="Custom gearbox">
+          <input type="hidden" id="gearbox" name="gearbox" value="{{ fleetData.gearbox }}">
           <div id="gearbox-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -255,8 +264,11 @@
       <div class="field-row" id="door_amount-row">
         <div class="field-body">
           <span class="field-label">Door Amount</span>
-          <input type="text" id="door_amount" name="door_amount" list="door_amount-datalist" value="{{ fleetData.door_amount }}" placeholder="Select or type a door amount...">
-          <datalist id="door_amount-datalist"></datalist>
+          <select id="door_amount-select" style="display:none;">
+            <option value="">Select a door amount...</option>
+          </select>
+          <input type="text" id="door_amount-manual" style="display:none;" placeholder="Custom door amount">
+          <input type="hidden" id="door_amount" name="door_amount" value="{{ fleetData.door_amount }}">
           <div id="door_amount-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -378,71 +390,147 @@
     <script>
       var typeLengthsMap = {{ type_lengths_json|safe }};
       var typeCategoryMap = {{ type_category_json|safe }};
+      var currentLength = '{{ fleetData.length|default_if_none:"" }}';
+
+      var typeEngineMap = {{ type_engine_json|safe }};
+      var typeGearboxMap = {{ type_gearbox_json|safe }};
+      var typeDoorMap = {{ type_door_json|safe }};
+      var currentEngine = '{{ fleetData.engine|default_if_none:"" }}';
+      var currentGearbox = '{{ fleetData.gearbox|default_if_none:"" }}';
+      var currentDoor = '{{ fleetData.door_amount|default_if_none:"" }}';
+
+      var FIELD_MANUAL_PLACEHOLDERS = {
+        'length': 'Custom length',
+        'engine': 'Custom engine',
+        'gearbox': 'Custom gearbox',
+        'door_amount': 'Custom door amount'
+      };
+
+      function populateTypeField(key, optionsMap, currentValue, selectPlaceholder) {
+        var select = document.getElementById(key + '-select');
+        var manual = document.getElementById(key + '-manual');
+        var hidden = document.getElementById(key);
+        if (!select || !manual || !hidden) return false;
+
+        var typeSelect = document.getElementById('type');
+        var selectedTypeId = parseInt(typeSelect.value);
+        var options = (isNaN(selectedTypeId) ? [] : (optionsMap[selectedTypeId] || [])).filter(function(o) { return o.trim() !== ''; });
+
+        manual.placeholder = FIELD_MANUAL_PLACEHOLDERS[key] || 'Value';
+
+        if (options.length === 0) {
+          select.style.display = 'none';
+          manual.style.display = '';
+          manual.value = currentValue;
+          hidden.value = currentValue;
+          return false;
+        }
+
+        while (select.options.length > 0) select.remove(0);
+        var placeholderOpt = document.createElement('option');
+        placeholderOpt.value = '';
+        placeholderOpt.textContent = selectPlaceholder;
+        select.appendChild(placeholderOpt);
+
+        var matched = false;
+        options.forEach(function(o) {
+          var opt = document.createElement('option');
+          opt.value = o;
+          if (o === currentValue) { opt.selected = true; matched = true; }
+          opt.textContent = o;
+          select.appendChild(opt);
+        });
+
+        var customOpt = document.createElement('option');
+        customOpt.value = '__custom__';
+        customOpt.textContent = 'Custom…';
+        select.appendChild(customOpt);
+
+        select.style.display = '';
+        if (currentValue !== '' && !matched) {
+          select.value = '__custom__';
+          manual.style.display = '';
+          manual.value = currentValue;
+        } else {
+          manual.style.display = 'none';
+          manual.value = '';
+          select.value = matched ? currentValue : '';
+        }
+        hidden.value = select.value === '__custom__' ? manual.value : select.value;
+        return true;
+      }
+
+      function syncHiddenFromSelect(key) {
+        var select = document.getElementById(key + '-select');
+        var manual = document.getElementById(key + '-manual');
+        var hidden = document.getElementById(key);
+        if (!select || !manual || !hidden) return;
+        if (select.value === '__custom__') {
+          manual.style.display = '';
+          manual.focus();
+          hidden.value = manual.value;
+        } else {
+          manual.style.display = 'none';
+          hidden.value = select.value;
+        }
+      }
+
+      function syncHiddenFromManual(key) {
+        var hidden = document.getElementById(key);
+        if (hidden) hidden.value = document.getElementById(key + '-manual').value;
+      }
 
       function updateLengthField() {
         var typeSelect = document.getElementById('type');
-        var lengthInput = document.getElementById('length');
-        var datalist = document.getElementById('length-datalist');
         var note = document.getElementById('length-note');
         var label = document.getElementById('length-label');
-        if (!typeSelect || !lengthInput || !datalist || !note || !label) return;
+        if (!typeSelect || !note || !label) return;
 
         var selectedTypeId = parseInt(typeSelect.value);
-
-        while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-        note.style.display = 'none';
-        label.textContent = 'Length';
-        lengthInput.placeholder = 'Select or type a length...';
-        lengthInput.oninput = null;
-
-        if (isNaN(selectedTypeId)) return;
-
         var category = typeCategoryMap[selectedTypeId];
+        var lengthManual = document.getElementById('length-manual');
+        var lengthHidden = document.getElementById('length');
+
+        note.style.display = 'none';
 
         if (category === 'Train' || category === 'Tram') {
           label.textContent = 'Car Amount';
-          lengthInput.placeholder = 'Number of cars';
-          lengthInput.oninput = function() {
+          document.getElementById('length-select').style.display = 'none';
+          lengthManual.style.display = '';
+          lengthManual.placeholder = 'Number of cars';
+          lengthManual.value = currentLength;
+          lengthManual.oninput = function() {
             this.value = this.value.replace(/[^0-9]/g, '');
+            syncHiddenFromManual('length');
           };
+          lengthHidden.value = lengthManual.value;
           return;
         }
 
-        var lengths = (typeLengthsMap[selectedTypeId] || []).filter(function(l) { return l.trim() !== ''; });
-        lengths.forEach(function(l) {
-          var opt = document.createElement('option');
-          opt.value = l;
-          opt.label = l + 'm';
-          datalist.appendChild(opt);
-        });
-        if (lengths.length === 0) {
+        label.textContent = 'Length';
+        lengthManual.oninput = function() { syncHiddenFromManual('length'); };
+        var hasOptions = populateTypeField('length', typeLengthsMap, currentLength, 'Select a length...');
+        if (!hasOptions) {
           note.style.display = '';
           var typeLink = '/operator/vehicle-types/' + selectedTypeId + '/';
           note.innerHTML = 'This vehicle type does not currently have any predefined lengths, you can add one here: <a href="' + typeLink + '">Edit Vehicle Type</a>';
         }
       }
 
-      var typeEngineMap = {{ type_engine_json|safe }};
-      var typeGearboxMap = {{ type_gearbox_json|safe }};
-      var typeDoorMap = {{ type_door_json|safe }};
-
       function updateTypeOptionsFields() {
-        var typeSelect = document.getElementById('type');
-        var selectedTypeId = parseInt(typeSelect.value);
-        var maps = { 'engine': typeEngineMap, 'gearbox': typeGearboxMap, 'door_amount': typeDoorMap };
-        ['engine', 'gearbox', 'door_amount'].forEach(function(key) {
-          var datalist = document.getElementById(key + '-datalist');
-          if (!datalist) return;
-          while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-          if (isNaN(selectedTypeId)) return;
-          var options = (maps[key][selectedTypeId] || []).filter(function(o) { return o.trim() !== ''; });
-          options.forEach(function(o) {
-            var opt = document.createElement('option');
-            opt.value = o;
-            datalist.appendChild(opt);
-          });
-        });
+        populateTypeField('engine', typeEngineMap, currentEngine, 'Select an engine...');
+        populateTypeField('gearbox', typeGearboxMap, currentGearbox, 'Select a gearbox...');
+        populateTypeField('door_amount', typeDoorMap, currentDoor, 'Select a door amount...');
       }
+
+      document.getElementById('length-select').addEventListener('change', function() { syncHiddenFromSelect('length'); });
+      document.getElementById('engine-select').addEventListener('change', function() { syncHiddenFromSelect('engine'); });
+      document.getElementById('gearbox-select').addEventListener('change', function() { syncHiddenFromSelect('gearbox'); });
+      document.getElementById('door_amount-select').addEventListener('change', function() { syncHiddenFromSelect('door_amount'); });
+
+      document.getElementById('engine-manual').addEventListener('input', function() { syncHiddenFromManual('engine'); });
+      document.getElementById('gearbox-manual').addEventListener('input', function() { syncHiddenFromManual('gearbox'); });
+      document.getElementById('door_amount-manual').addEventListener('input', function() { syncHiddenFromManual('door_amount'); });
 
       $('#type').on('change', function() {
         updateLengthField();

--- a/fleet/templates/edit.html
+++ b/fleet/templates/edit.html
@@ -226,8 +226,11 @@
       <div class="field-row" id="length-row">
         <div class="field-body">
           <span class="field-label" id="length-label">Length</span>
-          <input type="text" id="length" name="length" list="length-datalist" value="{{ fleetData.length|default_if_none:'' }}" placeholder="Select or type a length...">
-          <datalist id="length-datalist"></datalist>
+          <select id="length-select" style="display:none;">
+            <option value="">Select a length...</option>
+          </select>
+          <input type="text" id="length-manual" style="display:none;" placeholder="Custom length">
+          <input type="hidden" id="length" name="length" value="{{ fleetData.length|default_if_none:'' }}">
           <div id="length-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -235,8 +238,11 @@
       <div class="field-row" id="engine-row">
         <div class="field-body">
           <span class="field-label">Engine</span>
-          <input type="text" id="engine" name="engine" list="engine-datalist" value="{{ fleetData.engine }}" placeholder="Select or type an engine...">
-          <datalist id="engine-datalist"></datalist>
+          <select id="engine-select" style="display:none;">
+            <option value="">Select an engine...</option>
+          </select>
+          <input type="text" id="engine-manual" style="display:none;" placeholder="Custom engine">
+          <input type="hidden" id="engine" name="engine" value="{{ fleetData.engine }}">
           <div id="engine-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -244,8 +250,11 @@
       <div class="field-row" id="gearbox-row">
         <div class="field-body">
           <span class="field-label">Gearbox</span>
-          <input type="text" id="gearbox" name="gearbox" list="gearbox-datalist" value="{{ fleetData.gearbox }}" placeholder="Select or type a gearbox...">
-          <datalist id="gearbox-datalist"></datalist>
+          <select id="gearbox-select" style="display:none;">
+            <option value="">Select a gearbox...</option>
+          </select>
+          <input type="text" id="gearbox-manual" style="display:none;" placeholder="Custom gearbox">
+          <input type="hidden" id="gearbox" name="gearbox" value="{{ fleetData.gearbox }}">
           <div id="gearbox-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -253,8 +262,11 @@
       <div class="field-row" id="door_amount-row">
         <div class="field-body">
           <span class="field-label">Door Amount</span>
-          <input type="text" id="door_amount" name="door_amount" list="door_amount-datalist" value="{{ fleetData.door_amount }}" placeholder="Select or type a door amount...">
-          <datalist id="door_amount-datalist"></datalist>
+          <select id="door_amount-select" style="display:none;">
+            <option value="">Select a door amount...</option>
+          </select>
+          <input type="text" id="door_amount-manual" style="display:none;" placeholder="Custom door amount">
+          <input type="hidden" id="door_amount" name="door_amount" value="{{ fleetData.door_amount }}">
           <div id="door_amount-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -383,71 +395,147 @@
     <script>
       var typeLengthsMap = {{ type_lengths_json|safe }};
       var typeCategoryMap = {{ type_category_json|safe }};
+      var currentLength = '{{ fleetData.length|default_if_none:"" }}';
+
+      var typeEngineMap = {{ type_engine_json|safe }};
+      var typeGearboxMap = {{ type_gearbox_json|safe }};
+      var typeDoorMap = {{ type_door_json|safe }};
+      var currentEngine = '{{ fleetData.engine|default_if_none:"" }}';
+      var currentGearbox = '{{ fleetData.gearbox|default_if_none:"" }}';
+      var currentDoor = '{{ fleetData.door_amount|default_if_none:"" }}';
+
+      var FIELD_MANUAL_PLACEHOLDERS = {
+        'length': 'Custom length',
+        'engine': 'Custom engine',
+        'gearbox': 'Custom gearbox',
+        'door_amount': 'Custom door amount'
+      };
+
+      function populateTypeField(key, optionsMap, currentValue, selectPlaceholder) {
+        var select = document.getElementById(key + '-select');
+        var manual = document.getElementById(key + '-manual');
+        var hidden = document.getElementById(key);
+        if (!select || !manual || !hidden) return false;
+
+        var typeSelect = document.getElementById('type');
+        var selectedTypeId = parseInt(typeSelect.value);
+        var options = (isNaN(selectedTypeId) ? [] : (optionsMap[selectedTypeId] || [])).filter(function(o) { return o.trim() !== ''; });
+
+        manual.placeholder = FIELD_MANUAL_PLACEHOLDERS[key] || 'Value';
+
+        if (options.length === 0) {
+          select.style.display = 'none';
+          manual.style.display = '';
+          manual.value = currentValue;
+          hidden.value = currentValue;
+          return false;
+        }
+
+        while (select.options.length > 0) select.remove(0);
+        var placeholderOpt = document.createElement('option');
+        placeholderOpt.value = '';
+        placeholderOpt.textContent = selectPlaceholder;
+        select.appendChild(placeholderOpt);
+
+        var matched = false;
+        options.forEach(function(o) {
+          var opt = document.createElement('option');
+          opt.value = o;
+          if (o === currentValue) { opt.selected = true; matched = true; }
+          opt.textContent = o;
+          select.appendChild(opt);
+        });
+
+        var customOpt = document.createElement('option');
+        customOpt.value = '__custom__';
+        customOpt.textContent = 'Custom…';
+        select.appendChild(customOpt);
+
+        select.style.display = '';
+        if (currentValue !== '' && !matched) {
+          select.value = '__custom__';
+          manual.style.display = '';
+          manual.value = currentValue;
+        } else {
+          manual.style.display = 'none';
+          manual.value = '';
+          select.value = matched ? currentValue : '';
+        }
+        hidden.value = select.value === '__custom__' ? manual.value : select.value;
+        return true;
+      }
+
+      function syncHiddenFromSelect(key) {
+        var select = document.getElementById(key + '-select');
+        var manual = document.getElementById(key + '-manual');
+        var hidden = document.getElementById(key);
+        if (!select || !manual || !hidden) return;
+        if (select.value === '__custom__') {
+          manual.style.display = '';
+          manual.focus();
+          hidden.value = manual.value;
+        } else {
+          manual.style.display = 'none';
+          hidden.value = select.value;
+        }
+      }
+
+      function syncHiddenFromManual(key) {
+        var hidden = document.getElementById(key);
+        if (hidden) hidden.value = document.getElementById(key + '-manual').value;
+      }
 
       function updateLengthField() {
         var typeSelect = document.getElementById('type');
-        var lengthInput = document.getElementById('length');
-        var datalist = document.getElementById('length-datalist');
         var note = document.getElementById('length-note');
         var label = document.getElementById('length-label');
-        if (!typeSelect || !lengthInput || !datalist || !note || !label) return;
+        if (!typeSelect || !note || !label) return;
 
         var selectedTypeId = parseInt(typeSelect.value);
-
-        while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-        note.style.display = 'none';
-        label.textContent = 'Length';
-        lengthInput.placeholder = 'Select or type a length...';
-        lengthInput.oninput = null;
-
-        if (isNaN(selectedTypeId)) return;
-
         var category = typeCategoryMap[selectedTypeId];
+        var lengthManual = document.getElementById('length-manual');
+        var lengthHidden = document.getElementById('length');
+
+        note.style.display = 'none';
 
         if (category === 'Train' || category === 'Tram') {
           label.textContent = 'Car Amount';
-          lengthInput.placeholder = 'Number of cars';
-          lengthInput.oninput = function() {
+          document.getElementById('length-select').style.display = 'none';
+          lengthManual.style.display = '';
+          lengthManual.placeholder = 'Number of cars';
+          lengthManual.value = currentLength;
+          lengthManual.oninput = function() {
             this.value = this.value.replace(/[^0-9]/g, '');
+            syncHiddenFromManual('length');
           };
+          lengthHidden.value = lengthManual.value;
           return;
         }
 
-        var lengths = (typeLengthsMap[selectedTypeId] || []).filter(function(l) { return l.trim() !== ''; });
-        lengths.forEach(function(l) {
-          var opt = document.createElement('option');
-          opt.value = l;
-          opt.label = l + 'm';
-          datalist.appendChild(opt);
-        });
-        if (lengths.length === 0) {
+        label.textContent = 'Length';
+        lengthManual.oninput = function() { syncHiddenFromManual('length'); };
+        var hasOptions = populateTypeField('length', typeLengthsMap, currentLength, 'Select a length...');
+        if (!hasOptions) {
           note.style.display = '';
           var typeLink = '/operator/vehicle-types/' + selectedTypeId + '/';
           note.innerHTML = 'This vehicle type does not currently have any predefined lengths, you can add one here: <a href="' + typeLink + '">Edit Vehicle Type</a>';
         }
       }
 
-      var typeEngineMap = {{ type_engine_json|safe }};
-      var typeGearboxMap = {{ type_gearbox_json|safe }};
-      var typeDoorMap = {{ type_door_json|safe }};
-
       function updateTypeOptionsFields() {
-        var typeSelect = document.getElementById('type');
-        var selectedTypeId = parseInt(typeSelect.value);
-        var maps = { 'engine': typeEngineMap, 'gearbox': typeGearboxMap, 'door_amount': typeDoorMap };
-        ['engine', 'gearbox', 'door_amount'].forEach(function(key) {
-          var datalist = document.getElementById(key + '-datalist');
-          if (!datalist) return;
-          while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-          if (isNaN(selectedTypeId)) return;
-          var options = (maps[key][selectedTypeId] || []).filter(function(o) { return o.trim() !== ''; });
-          options.forEach(function(o) {
-            var opt = document.createElement('option');
-            opt.value = o;
-            datalist.appendChild(opt);
-          });
-        });
+        populateTypeField('engine', typeEngineMap, currentEngine, 'Select an engine...');
+        populateTypeField('gearbox', typeGearboxMap, currentGearbox, 'Select a gearbox...');
+        populateTypeField('door_amount', typeDoorMap, currentDoor, 'Select a door amount...');
       }
+
+      document.getElementById('length-select').addEventListener('change', function() { syncHiddenFromSelect('length'); });
+      document.getElementById('engine-select').addEventListener('change', function() { syncHiddenFromSelect('engine'); });
+      document.getElementById('gearbox-select').addEventListener('change', function() { syncHiddenFromSelect('gearbox'); });
+      document.getElementById('door_amount-select').addEventListener('change', function() { syncHiddenFromSelect('door_amount'); });
+
+      document.getElementById('engine-manual').addEventListener('input', function() { syncHiddenFromManual('engine'); });
+      document.getElementById('gearbox-manual').addEventListener('input', function() { syncHiddenFromManual('gearbox'); });
+      document.getElementById('door_amount-manual').addEventListener('input', function() { syncHiddenFromManual('door_amount'); });
 
       $('#type').on('change', function() {
         updateLengthField();

--- a/fleet/templates/mass_add.html
+++ b/fleet/templates/mass_add.html
@@ -257,8 +257,11 @@
       <div class="field-row" id="length-row">
         <div class="field-body">
           <span class="field-label" id="length-label">Length</span>
-          <input type="text" id="length" name="length" list="length-datalist" value="{{ fleetData.length|default_if_none:'' }}" placeholder="Select or type a length...">
-          <datalist id="length-datalist"></datalist>
+          <select id="length-select" style="display:none;">
+            <option value="">Select a length...</option>
+          </select>
+          <input type="text" id="length-manual" style="display:none;" placeholder="Custom length">
+          <input type="hidden" id="length" name="length" value="{{ fleetData.length|default_if_none:'' }}">
           <div id="length-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -266,8 +269,11 @@
       <div class="field-row" id="engine-row">
         <div class="field-body">
           <span class="field-label">Engine</span>
-          <input type="text" id="engine" name="engine" list="engine-datalist" value="{{ fleetData.engine }}" placeholder="Select or type an engine...">
-          <datalist id="engine-datalist"></datalist>
+          <select id="engine-select" style="display:none;">
+            <option value="">Select an engine...</option>
+          </select>
+          <input type="text" id="engine-manual" style="display:none;" placeholder="Custom engine">
+          <input type="hidden" id="engine" name="engine" value="{{ fleetData.engine }}">
           <div id="engine-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -275,8 +281,11 @@
       <div class="field-row" id="gearbox-row">
         <div class="field-body">
           <span class="field-label">Gearbox</span>
-          <input type="text" id="gearbox" name="gearbox" list="gearbox-datalist" value="{{ fleetData.gearbox }}" placeholder="Select or type a gearbox...">
-          <datalist id="gearbox-datalist"></datalist>
+          <select id="gearbox-select" style="display:none;">
+            <option value="">Select a gearbox...</option>
+          </select>
+          <input type="text" id="gearbox-manual" style="display:none;" placeholder="Custom gearbox">
+          <input type="hidden" id="gearbox" name="gearbox" value="{{ fleetData.gearbox }}">
           <div id="gearbox-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -284,8 +293,11 @@
       <div class="field-row" id="door_amount-row">
         <div class="field-body">
           <span class="field-label">Door Amount</span>
-          <input type="text" id="door_amount" name="door_amount" list="door_amount-datalist" value="{{ fleetData.door_amount }}" placeholder="Select or type a door amount...">
-          <datalist id="door_amount-datalist"></datalist>
+          <select id="door_amount-select" style="display:none;">
+            <option value="">Select a door amount...</option>
+          </select>
+          <input type="text" id="door_amount-manual" style="display:none;" placeholder="Custom door amount">
+          <input type="hidden" id="door_amount" name="door_amount" value="{{ fleetData.door_amount }}">
           <div id="door_amount-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -396,49 +408,148 @@
 <script>
 var typeLengthsMap = {{ type_lengths_json|safe }};
 var typeCategoryMap = {{ type_category_json|safe }};
+var typeEngineMap = {{ type_engine_json|safe }};
+var typeGearboxMap = {{ type_gearbox_json|safe }};
+var typeDoorMap = {{ type_door_json|safe }};
+
+var currentLength = '';
+var currentEngine = '';
+var currentGearbox = '';
+var currentDoor = '';
+
+var FIELD_MANUAL_PLACEHOLDERS = {
+  'length': 'Custom length',
+  'engine': 'Custom engine',
+  'gearbox': 'Custom gearbox',
+  'door_amount': 'Custom door amount'
+};
+
+function populateTypeField(key, optionsMap, currentValue, selectPlaceholder) {
+  var select = document.getElementById(key + '-select');
+  var manual = document.getElementById(key + '-manual');
+  var hidden = document.getElementById(key);
+  if (!select || !manual || !hidden) return false;
+
+  var typeSelect = document.getElementById('type');
+  var selectedTypeId = parseInt(typeSelect.value);
+  var options = (isNaN(selectedTypeId) ? [] : (optionsMap[selectedTypeId] || [])).filter(function(o) { return o.trim() !== ''; });
+
+  manual.placeholder = FIELD_MANUAL_PLACEHOLDERS[key] || 'Value';
+
+  if (options.length === 0) {
+    select.style.display = 'none';
+    manual.style.display = '';
+    manual.value = currentValue;
+    hidden.value = currentValue;
+    return false;
+  }
+
+  while (select.options.length > 0) select.remove(0);
+  var placeholderOpt = document.createElement('option');
+  placeholderOpt.value = '';
+  placeholderOpt.textContent = selectPlaceholder;
+  select.appendChild(placeholderOpt);
+
+  var matched = false;
+  options.forEach(function(o) {
+    var opt = document.createElement('option');
+    opt.value = o;
+    if (o === currentValue) { opt.selected = true; matched = true; }
+    opt.textContent = o;
+    select.appendChild(opt);
+  });
+
+  var customOpt = document.createElement('option');
+  customOpt.value = '__custom__';
+  customOpt.textContent = 'Custom…';
+  select.appendChild(customOpt);
+
+  select.style.display = '';
+  if (currentValue !== '' && !matched) {
+    select.value = '__custom__';
+    manual.style.display = '';
+    manual.value = currentValue;
+  } else {
+    manual.style.display = 'none';
+    manual.value = '';
+    select.value = matched ? currentValue : '';
+  }
+  hidden.value = select.value === '__custom__' ? manual.value : select.value;
+  return true;
+}
+
+function syncHiddenFromSelect(key) {
+  var select = document.getElementById(key + '-select');
+  var manual = document.getElementById(key + '-manual');
+  var hidden = document.getElementById(key);
+  if (!select || !manual || !hidden) return;
+  if (select.value === '__custom__') {
+    manual.style.display = '';
+    manual.focus();
+    hidden.value = manual.value;
+  } else {
+    manual.style.display = 'none';
+    hidden.value = select.value;
+  }
+}
+
+function syncHiddenFromManual(key) {
+  var hidden = document.getElementById(key);
+  if (hidden) hidden.value = document.getElementById(key + '-manual').value;
+}
 
 function updateLengthField() {
   var typeSelect = document.getElementById('type');
-  var lengthInput = document.getElementById('length');
-  var datalist = document.getElementById('length-datalist');
   var note = document.getElementById('length-note');
   var label = document.getElementById('length-label');
-  if (!typeSelect || !lengthInput || !datalist || !note || !label) return;
+  if (!typeSelect || !note || !label) return;
 
   var selectedTypeId = parseInt(typeSelect.value);
-
-  while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-  note.style.display = 'none';
-  label.textContent = 'Length';
-  lengthInput.placeholder = 'Select or type a length...';
-  lengthInput.oninput = null;
-
-  if (isNaN(selectedTypeId)) return;
-
   var category = typeCategoryMap[selectedTypeId];
+  var lengthManual = document.getElementById('length-manual');
+  var lengthHidden = document.getElementById('length');
+  var lengthSelect = document.getElementById('length-select');
+
+  note.style.display = 'none';
 
   if (category === 'Train' || category === 'Tram') {
     label.textContent = 'Car Amount';
-    lengthInput.placeholder = 'Number of cars';
-    lengthInput.oninput = function() {
+    lengthSelect.style.display = 'none';
+    lengthManual.style.display = '';
+    lengthManual.placeholder = 'Number of cars';
+    lengthManual.value = currentLength;
+    lengthManual.oninput = function() {
       this.value = this.value.replace(/[^0-9]/g, '');
+      syncHiddenFromManual('length');
     };
+    lengthHidden.value = lengthManual.value;
     return;
   }
 
-  var lengths = (typeLengthsMap[selectedTypeId] || []).filter(function(l) { return l.trim() !== ''; });
-  lengths.forEach(function(l) {
-    var opt = document.createElement('option');
-    opt.value = l;
-    opt.label = l + 'm';
-    datalist.appendChild(opt);
-  });
-  if (lengths.length === 0) {
+  label.textContent = 'Length';
+  lengthManual.oninput = function() { syncHiddenFromManual('length'); };
+  var hasOptions = populateTypeField('length', typeLengthsMap, currentLength, 'Select a length...');
+  if (!hasOptions) {
     note.style.display = '';
     var typeLink = '/operator/vehicle-types/' + selectedTypeId + '/';
     note.innerHTML = 'This vehicle type does not currently have any predefined lengths, you can add one here: <a href="' + typeLink + '">Edit Vehicle Type</a>';
   }
 }
+
+function updateTypeOptionsFields() {
+  populateTypeField('engine', typeEngineMap, currentEngine, 'Select an engine...');
+  populateTypeField('gearbox', typeGearboxMap, currentGearbox, 'Select a gearbox...');
+  populateTypeField('door_amount', typeDoorMap, currentDoor, 'Select a door amount...');
+}
+
+document.getElementById('length-select').addEventListener('change', function() { syncHiddenFromSelect('length'); });
+document.getElementById('engine-select').addEventListener('change', function() { syncHiddenFromSelect('engine'); });
+document.getElementById('gearbox-select').addEventListener('change', function() { syncHiddenFromSelect('gearbox'); });
+document.getElementById('door_amount-select').addEventListener('change', function() { syncHiddenFromSelect('door_amount'); });
+
+document.getElementById('engine-manual').addEventListener('input', function() { syncHiddenFromManual('engine'); });
+document.getElementById('gearbox-manual').addEventListener('input', function() { syncHiddenFromManual('gearbox'); });
+document.getElementById('door_amount-manual').addEventListener('input', function() { syncHiddenFromManual('door_amount'); });
 
 $(document).ready(function() {
     function stripFavouritePrefix(text) {
@@ -1036,28 +1147,6 @@ document.addEventListener('DOMContentLoaded', function () {
     updateLengthField();
     updateTypeOptionsFields();
   });
-
-  var typeEngineMap = {{ type_engine_json|safe }};
-  var typeGearboxMap = {{ type_gearbox_json|safe }};
-  var typeDoorMap = {{ type_door_json|safe }};
-
-  function updateTypeOptionsFields() {
-    var typeSelect = document.getElementById('type');
-    var selectedTypeId = parseInt(typeSelect.value);
-    var maps = { 'engine': typeEngineMap, 'gearbox': typeGearboxMap, 'door_amount': typeDoorMap };
-    ['engine', 'gearbox', 'door_amount'].forEach(function(key) {
-      var datalist = document.getElementById(key + '-datalist');
-      if (!datalist) return;
-      while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-      if (isNaN(selectedTypeId)) return;
-      var options = (maps[key][selectedTypeId] || []).filter(function(o) { return o.trim() !== ''; });
-      options.forEach(function(o) {
-        var opt = document.createElement('option');
-        opt.value = o;
-        datalist.appendChild(opt);
-      });
-    });
-  }
 
   updateLengthField();
   updateTypeOptionsFields();

--- a/fleet/templates/mass_edit.html
+++ b/fleet/templates/mass_edit.html
@@ -396,8 +396,11 @@
         <label class="toggle-dot" for="edit_length" aria-label="Enable length editing"><span class="dot"></span></label>
         <div class="field-body">
           <span class="field-label" id="length-label">Length</span>
-          <input type="text" id="length" name="length" list="length-datalist" value="{{ fleetData.length|default_if_none:'' }}" placeholder="Select or type a length...">
-          <datalist id="length-datalist"></datalist>
+          <select id="length-select" style="display:none;">
+            <option value="">Select a length...</option>
+          </select>
+          <input type="text" id="length-manual" style="display:none;" placeholder="Custom length">
+          <input type="hidden" id="length" name="length" value="{{ fleetData.length|default_if_none:'' }}">
           <div id="length-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -407,8 +410,11 @@
         <label class="toggle-dot" for="edit_engine" aria-label="Enable engine editing"><span class="dot"></span></label>
         <div class="field-body">
           <span class="field-label">Engine</span>
-          <input type="text" id="engine" name="engine" list="engine-datalist" value="{{ fleetData.engine }}" placeholder="Select or type an engine...">
-          <datalist id="engine-datalist"></datalist>
+          <select id="engine-select" style="display:none;">
+            <option value="">Select an engine...</option>
+          </select>
+          <input type="text" id="engine-manual" style="display:none;" placeholder="Custom engine">
+          <input type="hidden" id="engine" name="engine" value="{{ fleetData.engine }}">
           <div id="engine-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -418,8 +424,11 @@
         <label class="toggle-dot" for="edit_gearbox" aria-label="Enable gearbox editing"><span class="dot"></span></label>
         <div class="field-body">
           <span class="field-label">Gearbox</span>
-          <input type="text" id="gearbox" name="gearbox" list="gearbox-datalist" value="{{ fleetData.gearbox }}" placeholder="Select or type a gearbox...">
-          <datalist id="gearbox-datalist"></datalist>
+          <select id="gearbox-select" style="display:none;">
+            <option value="">Select a gearbox...</option>
+          </select>
+          <input type="text" id="gearbox-manual" style="display:none;" placeholder="Custom gearbox">
+          <input type="hidden" id="gearbox" name="gearbox" value="{{ fleetData.gearbox }}">
           <div id="gearbox-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -429,8 +438,11 @@
         <label class="toggle-dot" for="edit_door_amount" aria-label="Enable door amount editing"><span class="dot"></span></label>
         <div class="field-body">
           <span class="field-label">Door Amount</span>
-          <input type="text" id="door_amount" name="door_amount" list="door_amount-datalist" value="{{ fleetData.door_amount }}" placeholder="Select or type a door amount...">
-          <datalist id="door_amount-datalist"></datalist>
+          <select id="door_amount-select" style="display:none;">
+            <option value="">Select a door amount...</option>
+          </select>
+          <input type="text" id="door_amount-manual" style="display:none;" placeholder="Custom door amount">
+          <input type="hidden" id="door_amount" name="door_amount" value="{{ fleetData.door_amount }}">
           <div id="door_amount-note" style="display:none; font-size: 0.85em; padding: 2px 4px;"></div>
         </div>
       </div>
@@ -566,71 +578,149 @@
     <script>
       var typeLengthsMap = {{ type_lengths_json|safe }};
       var typeCategoryMap = {{ type_category_json|safe }};
+      var typeEngineMap = {{ type_engine_json|safe }};
+      var typeGearboxMap = {{ type_gearbox_json|safe }};
+      var typeDoorMap = {{ type_door_json|safe }};
+
+      var currentFieldValue = function(key) {
+        var el = document.getElementById(key);
+        return el ? el.value : '';
+      };
+
+      var FIELD_MANUAL_PLACEHOLDERS = {
+        'length': 'Custom length',
+        'engine': 'Custom engine',
+        'gearbox': 'Custom gearbox',
+        'door_amount': 'Custom door amount'
+      };
+
+      function populateTypeField(key, optionsMap, currentValue, selectPlaceholder) {
+        var select = document.getElementById(key + '-select');
+        var manual = document.getElementById(key + '-manual');
+        var hidden = document.getElementById(key);
+        if (!select || !manual || !hidden) return false;
+
+        var typeSelect = document.getElementById('type');
+        var selectedTypeId = parseInt(typeSelect.value);
+        var options = (isNaN(selectedTypeId) ? [] : (optionsMap[selectedTypeId] || [])).filter(function(o) { return o.trim() !== ''; });
+
+        manual.placeholder = FIELD_MANUAL_PLACEHOLDERS[key] || 'Value';
+
+        if (options.length === 0) {
+          select.style.display = 'none';
+          manual.style.display = '';
+          manual.value = currentValue;
+          hidden.value = currentValue;
+          return false;
+        }
+
+        while (select.options.length > 0) select.remove(0);
+        var placeholderOpt = document.createElement('option');
+        placeholderOpt.value = '';
+        placeholderOpt.textContent = selectPlaceholder;
+        select.appendChild(placeholderOpt);
+
+        var matched = false;
+        options.forEach(function(o) {
+          var opt = document.createElement('option');
+          opt.value = o;
+          if (o === currentValue) { opt.selected = true; matched = true; }
+          opt.textContent = o;
+          select.appendChild(opt);
+        });
+
+        var customOpt = document.createElement('option');
+        customOpt.value = '__custom__';
+        customOpt.textContent = 'Custom…';
+        select.appendChild(customOpt);
+
+        select.style.display = '';
+        if (currentValue !== '' && !matched) {
+          select.value = '__custom__';
+          manual.style.display = '';
+          manual.value = currentValue;
+        } else {
+          manual.style.display = 'none';
+          manual.value = '';
+          select.value = matched ? currentValue : '';
+        }
+        hidden.value = select.value === '__custom__' ? manual.value : select.value;
+        return true;
+      }
+
+      function syncHiddenFromSelect(key) {
+        var select = document.getElementById(key + '-select');
+        var manual = document.getElementById(key + '-manual');
+        var hidden = document.getElementById(key);
+        if (!select || !manual || !hidden) return;
+        if (select.value === '__custom__') {
+          manual.style.display = '';
+          manual.focus();
+          hidden.value = manual.value;
+        } else {
+          manual.style.display = 'none';
+          hidden.value = select.value;
+        }
+      }
+
+      function syncHiddenFromManual(key) {
+        var hidden = document.getElementById(key);
+        if (hidden) hidden.value = document.getElementById(key + '-manual').value;
+      }
 
       function updateLengthField() {
         var typeSelect = document.getElementById('type');
-        var lengthInput = document.getElementById('length');
-        var datalist = document.getElementById('length-datalist');
         var note = document.getElementById('length-note');
         var label = document.getElementById('length-label');
-        if (!typeSelect || !lengthInput || !datalist || !note || !label) return;
+        if (!typeSelect || !note || !label) return;
 
         var selectedTypeId = parseInt(typeSelect.value);
-
-        while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-        note.style.display = 'none';
-        label.textContent = 'Length';
-        lengthInput.placeholder = 'Select or type a length...';
-        lengthInput.oninput = null;
-
-        if (isNaN(selectedTypeId)) return;
-
         var category = typeCategoryMap[selectedTypeId];
+        var lengthManual = document.getElementById('length-manual');
+        var lengthHidden = document.getElementById('length');
+        var lengthSelect = document.getElementById('length-select');
+        var currentLength = currentFieldValue('length');
+
+        note.style.display = 'none';
 
         if (category === 'Train' || category === 'Tram') {
           label.textContent = 'Car Amount';
-          lengthInput.placeholder = 'Number of cars';
-          lengthInput.oninput = function() {
+          lengthSelect.style.display = 'none';
+          lengthManual.style.display = '';
+          lengthManual.placeholder = 'Number of cars';
+          lengthManual.value = currentLength;
+          lengthManual.oninput = function() {
             this.value = this.value.replace(/[^0-9]/g, '');
+            syncHiddenFromManual('length');
           };
+          lengthHidden.value = lengthManual.value;
           return;
         }
 
-        var lengths = (typeLengthsMap[selectedTypeId] || []).filter(function(l) { return l.trim() !== ''; });
-        lengths.forEach(function(l) {
-          var opt = document.createElement('option');
-          opt.value = l;
-          opt.label = l + 'm';
-          datalist.appendChild(opt);
-        });
-        if (lengths.length === 0) {
+        label.textContent = 'Length';
+        lengthManual.oninput = function() { syncHiddenFromManual('length'); };
+        var hasOptions = populateTypeField('length', typeLengthsMap, currentLength, 'Select a length...');
+        if (!hasOptions) {
           note.style.display = '';
           var typeLink = '/operator/vehicle-types/' + selectedTypeId + '/';
           note.innerHTML = 'This vehicle type does not currently have any predefined lengths, you can add one here: <a href="' + typeLink + '">Edit Vehicle Type</a>';
         }
       }
 
-      var typeEngineMap = {{ type_engine_json|safe }};
-      var typeGearboxMap = {{ type_gearbox_json|safe }};
-      var typeDoorMap = {{ type_door_json|safe }};
-
       function updateTypeOptionsFields() {
-        var typeSelect = document.getElementById('type');
-        var selectedTypeId = parseInt(typeSelect.value);
-        var maps = { 'engine': typeEngineMap, 'gearbox': typeGearboxMap, 'door_amount': typeDoorMap };
-        ['engine', 'gearbox', 'door_amount'].forEach(function(key) {
-          var datalist = document.getElementById(key + '-datalist');
-          if (!datalist) return;
-          while (datalist.firstChild) datalist.removeChild(datalist.firstChild);
-          if (isNaN(selectedTypeId)) return;
-          var options = (maps[key][selectedTypeId] || []).filter(function(o) { return o.trim() !== ''; });
-          options.forEach(function(o) {
-            var opt = document.createElement('option');
-            opt.value = o;
-            datalist.appendChild(opt);
-          });
-        });
+        populateTypeField('engine', typeEngineMap, currentFieldValue('engine'), 'Select an engine...');
+        populateTypeField('gearbox', typeGearboxMap, currentFieldValue('gearbox'), 'Select a gearbox...');
+        populateTypeField('door_amount', typeDoorMap, currentFieldValue('door_amount'), 'Select a door amount...');
       }
+
+      document.getElementById('length-select').addEventListener('change', function() { syncHiddenFromSelect('length'); });
+      document.getElementById('engine-select').addEventListener('change', function() { syncHiddenFromSelect('engine'); });
+      document.getElementById('gearbox-select').addEventListener('change', function() { syncHiddenFromSelect('gearbox'); });
+      document.getElementById('door_amount-select').addEventListener('change', function() { syncHiddenFromSelect('door_amount'); });
+
+      document.getElementById('engine-manual').addEventListener('input', function() { syncHiddenFromManual('engine'); });
+      document.getElementById('gearbox-manual').addEventListener('input', function() { syncHiddenFromManual('gearbox'); });
+      document.getElementById('door_amount-manual').addEventListener('input', function() { syncHiddenFromManual('door_amount'); });
 
       $('#type').on('change', function() {
         updateLengthField();

--- a/main/templates/mbtbase-adfirst.html
+++ b/main/templates/mbtbase-adfirst.html
@@ -283,7 +283,7 @@
       style="max-width: 1em;max-height:1em;margin-left: .2em;margin-bottom: 0;">
   </footer>
   <p style="position: absolute;left: 0; background: var(--brand-color);padding: 5px;border-radius: 0px 10px 0px 0px;">
-    MyBusTimes: V1.8.26</p>
+    MyBusTimes: V26.8.11</p>
 </body>
 
 </html>

--- a/main/templates/mbtbase.html
+++ b/main/templates/mbtbase.html
@@ -308,6 +308,6 @@
   </footer>
   {% include "extra/word.html" %}
   <p style="position: absolute;left: 0; background: var(--brand-color);padding: 5px;border-radius: 0px 10px 0px 0px;">
-    MyBusTimes: V1.8.26</p>
+    MyBusTimes: V26.8.11</p>
 </body>
 {% endif %}

--- a/tracking/views.py
+++ b/tracking/views.py
@@ -127,6 +127,17 @@ def StartNewTripView(request):
             if timezone.is_naive(parsed):
                 parsed = timezone.make_aware(parsed, timezone.get_current_timezone())
             trip_start_at = parsed
+        trip_end_at_raw = data.get("trip_end_date_time")  # should be ISO8601 string
+        trip_end_at = None
+        if trip_end_at_raw:
+            parsed_end = parse_datetime(trip_end_at_raw)
+            # If parse_datetime returned None, the input wasn't valid ISO8601
+            if parsed_end is None:
+                return JsonResponse({"error": "trip_end_date_time is invalid ISO8601"}, status=400)
+            # Make timezone-aware if naive
+            if timezone.is_naive(parsed_end):
+                parsed_end = timezone.make_aware(parsed_end, timezone.get_current_timezone())
+            trip_end_at = parsed_end
     except Exception as e:
         return JsonResponse({"error": "Invalid request data", "details": str(e)}, status=400)
 
@@ -167,15 +178,26 @@ def StartNewTripView(request):
             route_obj = None
 
     # Create Trip
+    trip_start = trip_start_at or timezone.now()
+    trip_end = trip_end_at or (trip_start + timezone.timedelta(hours=1))
+
+    if trip_end <= trip_start:
+        return JsonResponse({"error": "trip_end_date_time must be after trip start"}, status=400)
+
     trip = Trip.objects.create(
         trip_vehicle=vehicle,
         trip_route=route_obj,
         trip_route_num=route_number,
         trip_end_location=trip_end_location,
-        trip_start_at=trip_start_at or timezone.now(),
-        trip_driver = user
+        trip_start_at=trip_start,
+        trip_end_at=trip_end,
+        trip_driver=user
         # You may want to attach the driver via session_key -> CustomUser lookup
     )
+
+    # Link the vehicle to this trip so it appears on the live map
+    vehicle.current_trip = trip
+    vehicle.save(update_fields=["current_trip"])
 
     # Create Tracking (initial data)
     tracking = Tracking.objects.create(
@@ -636,4 +658,97 @@ def push_sim_position(request, vehicle_id=None):
         "lon": vehicle.sim_lon,
         "rotation": vehicle.sim_heading,
         "updated_at": vehicle.updated_at.isoformat() if vehicle.updated_at else None,
+    }, status=200)
+
+
+@csrf_exempt
+def push_trip_position(request, trip_id=None):
+    """Append a position onto the trail of a live trip's Tracking row.
+
+    Works exactly like a regular logged trip: each call updates tracking_data
+    and the Tracking model's save() appends a timestamped snapshot to
+    tracking_history_data, which the trip page renders as the trail.
+
+    Auth: same session-key mechanism as the ticketer code system (see
+    push_sim_position). The user must own the trip's vehicle operator or be
+    listed as a helper.
+    """
+    if request.method != "POST":
+        return JsonResponse({"error": "Only POST method is allowed", "status": 405, "method": request.method}, status=405)
+
+    try:
+        data = json.loads(request.body.decode("utf-8") or "{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    session_key = data.get("session_key")
+    if not session_key:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("SessionKey "):
+            session_key = auth_header[len("SessionKey "):]
+    if not session_key:
+        return JsonResponse({"error": "Missing session_key"}, status=401)
+
+    try:
+        user_key = UserKeys.objects.select_related("user").get(session_key=session_key)
+        user = user_key.user
+    except UserKeys.DoesNotExist:
+        return JsonResponse({"error": "Invalid session key"}, status=401)
+
+    try:
+        tracking = (
+            Tracking.objects.filter(tracking_trip_id=trip_id, trip_ended=False)
+            .select_related("tracking_vehicle", "tracking_vehicle__operator")
+            .order_by("-tracking_id")
+            .first()
+        )
+    except Exception:
+        tracking = None
+    if not tracking:
+        return JsonResponse({"error": "Trip not found"}, status=404)
+
+    vehicle = tracking.tracking_vehicle
+    operator_inst = vehicle.operator
+    if operator_inst.owner != user:
+        is_helper = helper.objects.filter(operator=operator_inst, helper=user).exists()
+        if not is_helper:
+            return JsonResponse({"error": "Permission denied"}, status=403)
+
+    try:
+        lat = float(data.get("lat"))
+        lon = float(data.get("lon"))
+    except (TypeError, ValueError):
+        return JsonResponse({"error": "lat and lon are required numeric fields"}, status=400)
+
+    if not (-90.0 <= lat <= 90.0):
+        return JsonResponse({"error": "lat must be between -90 and 90"}, status=400)
+    if not (-180.0 <= lon <= 180.0):
+        return JsonResponse({"error": "lon must be between -180 and 180"}, status=400)
+
+    rotation = data.get("rotation")
+    if rotation is not None:
+        try:
+            rotation = float(rotation)
+        except (TypeError, ValueError):
+            return JsonResponse({"error": "rotation must be numeric"}, status=400)
+    else:
+        rotation = 0.0
+
+    current_data = tracking.tracking_data or {}
+    tracking.tracking_data = {
+        "X": lat,
+        "Y": lon,
+        "delay": data.get("delay", current_data.get("delay", 0)),
+        "heading": rotation,
+        "current_stop_idx": current_data.get("current_stop_idx", "0"),
+    }
+    tracking.save()
+
+    return JsonResponse({
+        "success": True,
+        "trip_id": trip_id,
+        "tracking_id": tracking.tracking_id,
+        "lat": lat,
+        "lon": lon,
+        "rotation": rotation,
     }, status=200)


### PR DESCRIPTION
Add a POST endpoint to append positions to a live trip (/api/trips/<trip_id>/tracking/) with session-key auth and permission checks; implement push_trip_position view in tracking/views.py and register its URL. Add docs/api_push_sim_position.md documenting the simulated position API. Enhance StartNewTripView to accept/validate trip_end_date_time, set sane defaults, ensure end > start, and link vehicle.current_trip. Refactor fleet forms (add/edit/mass_add/mass_edit) to replace datalist inputs with select + manual + hidden inputs and add JS helpers (populateTypeField, sync functions) to populate and sync engine/gearbox/door_amount/length fields. Bump displayed app version in base templates. Minor JS/templating adjustments to support new UI behavior.